### PR TITLE
Fix: Replace 'due today' and 'due now' with just 'due'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+
+jobs:
+    test-and-lint:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+                  cache: "npm"
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Run linter
+              run: npm run lint
+
+            - name: Run tests
+              run: npm run test
+
+            - name: Build
+              run: npm run build

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,50 +1,55 @@
 name: Claude Code
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-  issues:
-    types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+    issue_comment:
+        types: [created]
+    pull_request_review_comment:
+        types: [created]
+    issues:
+        types: [opened, assigned]
+    pull_request_review:
+        types: [submitted]
 
 jobs:
-  claude:
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+    claude:
+        if: |
+            (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+            (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+            (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+            (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: read
+            issues: read
+            id-token: write
+            actions: read # Required for Claude to read CI results on PRs
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 1
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+            - name: Install dependencies
+              run: npm ci
 
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+            - name: Run Claude Code
+              id: claude
+              uses: anthropics/claude-code-action@v1
+              with:
+                  claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
+                  # This is an optional setting that allows Claude to read CI results on PRs
+                  additional_permissions: |
+                      actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+                  # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+                  # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-
+                  # Optional: Add claude_args to customize behavior and configuration
+                  # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+                  # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+                  # claude_args: '--allowed-tools Bash(gh pr:*)'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Screenshot
 
-<img width="1126" height="467" alt="image" src="https://github.com/user-attachments/assets/3f416409-0e9b-4ef3-b52e-cff57c0d9ded" />
+<img width="1121" height="585" alt="image" src="https://github.com/user-attachments/assets/ffba8260-ccdf-43be-89c5-95b0b75c9706" />
 
 (The screenshot might not be up to date)
 
@@ -29,8 +29,6 @@ Create a symbolic link to develop the plugin in your vault:
 ```sh
 npm run dev:link --vault=/path/to/your/vault
 ```
-
-This will create a symlink at `/path/to/your/vault/.obsidian/plugins/plugin-template`
 
 ### Build for production
 

--- a/main.ts
+++ b/main.ts
@@ -233,7 +233,7 @@ export default class IncrementalReadingPlugin extends Plugin {
 		}
 
 		await this.queueManager.addToQueue(activeFile.path, 0);
-		new Notice(`Added "${activeFile.basename}" to queue (due now)`);
+		new Notice(`Added "${activeFile.basename}" to queue (due)`);
 
 		// Update counters
 		if (this.onCountersChanged) {

--- a/main.ts
+++ b/main.ts
@@ -233,7 +233,7 @@ export default class IncrementalReadingPlugin extends Plugin {
 		}
 
 		await this.queueManager.addToQueue(activeFile.path, 0);
-		new Notice(`Added "${activeFile.basename}" to queue (due today)`);
+		new Notice(`Added "${activeFile.basename}" to queue (due now)`);
 
 		// Update counters
 		if (this.onCountersChanged) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"lint": "eslint src/**/*.ts",
 		"format": "prettier --write .",
-		"test": "npx tsx src/nextNoteSelector.test.ts",
+		"test": "vitest run",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",
 		"prepare": "husky"
 	},
@@ -21,7 +21,7 @@
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
-		"@types/node": "^16.11.6",
+		"@types/node": "^20.19.19",
 		"@types/react": "^19.2.0",
 		"@types/react-dom": "^19.2.0",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
@@ -33,7 +33,8 @@
 		"obsidian": "latest",
 		"prettier": "^3.6.2",
 		"tslib": "2.4.0",
-		"typescript": "4.7.4"
+		"typescript": "4.7.4",
+		"vitest": "^3.2.4"
 	},
 	"lint-staged": {
 		"*": "prettier --write --ignore-unknown"

--- a/src/SidebarView.tsx
+++ b/src/SidebarView.tsx
@@ -9,8 +9,7 @@ interface SidebarViewProps {
 }
 
 export const SidebarView: React.FC<SidebarViewProps> = ({ app, plugin }) => {
-	const [dueNowCount, setDueNowCount] = useState<number>(0);
-	const [dueTodayCount, setDueTodayCount] = useState<number>(0);
+	const [dueCount, setDueCount] = useState<number>(0);
 	const [totalCount, setTotalCount] = useState<number>(0);
 	const [status, setStatus] = useState<string>("");
 	const [statusHappy, setStatusHappy] = useState<boolean>(false);
@@ -20,8 +19,7 @@ export const SidebarView: React.FC<SidebarViewProps> = ({ app, plugin }) => {
 	const updateCounters = async () => {
 		// Use cache for UI display - it's okay if it's slightly stale
 		const stats = await plugin.queueManager.getQueueStats(true);
-		setDueNowCount(stats.dueNow);
-		setDueTodayCount(stats.dueToday);
+		setDueCount(stats.due);
 		setTotalCount(stats.total);
 	};
 
@@ -104,17 +102,14 @@ export const SidebarView: React.FC<SidebarViewProps> = ({ app, plugin }) => {
 				}}
 			>
 				<div style={{ marginBottom: "5px" }}>
-					Due now: {dueNowCount}
-				</div>
-				<div style={{ marginBottom: "5px" }}>
-					Due today: {dueTodayCount}
+					Due: {dueCount}
 				</div>
 				<div>Total in queue: {totalCount}</div>
 			</div>
 
 			{/* Show Next button - primary only when there are notes to show */}
 			<button
-				className={dueNowCount > 0 ? "mod-cta" : ""}
+				className={dueCount > 0 ? "mod-cta" : ""}
 				style={{ marginBottom: "10px", width: "100%" }}
 				onClick={handleShowNext}
 			>

--- a/src/SidebarView.tsx
+++ b/src/SidebarView.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { App } from "obsidian";
 import IncrementalReadingPlugin from "../main";
 import { Rating } from "ts-fsrs";
+import { CardStats, IntervalPreviews } from "./types";
 
 interface SidebarViewProps {
 	app: App;
@@ -15,6 +16,9 @@ export const SidebarView: React.FC<SidebarViewProps> = ({ app, plugin }) => {
 	const [statusHappy, setStatusHappy] = useState<boolean>(false);
 	const [showDifficultyButtons, setShowDifficultyButtons] =
 		useState<boolean>(false);
+	const [cardStats, setCardStats] = useState<CardStats | null>(null);
+	const [intervalPreviews, setIntervalPreviews] =
+		useState<IntervalPreviews | null>(null);
 
 	const updateCounters = async () => {
 		// Use cache for UI display - it's okay if it's slightly stale
@@ -39,10 +43,20 @@ export const SidebarView: React.FC<SidebarViewProps> = ({ app, plugin }) => {
 
 		plugin.onHideDifficultyPrompt = () => {
 			setShowDifficultyButtons(false);
+			setCardStats(null);
+			setIntervalPreviews(null);
 		};
 
 		plugin.onCountersChanged = () => {
 			updateCounters();
+		};
+
+		plugin.onCardStatsChanged = (
+			stats: CardStats,
+			intervals: IntervalPreviews,
+		) => {
+			setCardStats(stats);
+			setIntervalPreviews(intervals);
 		};
 
 		// Auto-refresh counters every 30 seconds
@@ -56,6 +70,7 @@ export const SidebarView: React.FC<SidebarViewProps> = ({ app, plugin }) => {
 			plugin.onShowDifficultyPrompt = undefined;
 			plugin.onHideDifficultyPrompt = undefined;
 			plugin.onCountersChanged = undefined;
+			plugin.onCardStatsChanged = undefined;
 			clearInterval(refreshInterval);
 		};
 	}, [plugin]);
@@ -124,6 +139,31 @@ export const SidebarView: React.FC<SidebarViewProps> = ({ app, plugin }) => {
 				Add Current Note to Queue
 			</button>
 
+			{/* Card Statistics (when reviewing) */}
+			{cardStats && (
+				<div
+					style={{
+						marginTop: "15px",
+						padding: "10px",
+						backgroundColor: "var(--background-secondary)",
+						borderRadius: "5px",
+						fontSize: "0.9em",
+					}}
+				>
+					<div style={{ marginBottom: "3px" }}>
+						<strong>Card Stats:</strong>
+					</div>
+					<div style={{ marginBottom: "2px" }}>
+						Memory: {cardStats.stability}d | Difficulty:{" "}
+						{cardStats.difficulty}/10
+					</div>
+					<div style={{ fontSize: "0.85em", opacity: 0.8 }}>
+						Reviews: {cardStats.reps} | Forgotten:{" "}
+						{cardStats.lapses}
+					</div>
+				</div>
+			)}
+
 			{/* Status message area */}
 			<div
 				style={{
@@ -136,6 +176,18 @@ export const SidebarView: React.FC<SidebarViewProps> = ({ app, plugin }) => {
 				}}
 			>
 				{status}
+				{showDifficultyButtons && intervalPreviews && (
+					<div
+						style={{
+							marginTop: "10px",
+							marginBottom: "5px",
+							fontSize: "0.85em",
+							opacity: 0.7,
+						}}
+					>
+						Next review intervals:
+					</div>
+				)}
 				{showDifficultyButtons && (
 					<div
 						style={{
@@ -147,9 +199,19 @@ export const SidebarView: React.FC<SidebarViewProps> = ({ app, plugin }) => {
 					>
 						<button style={{ flex: "1" }} onClick={handleMarkAgain}>
 							Again
+							{intervalPreviews && (
+								<div style={{ fontSize: "0.75em", opacity: 0.7 }}>
+									{intervalPreviews[Rating.Again]}
+								</div>
+							)}
 						</button>
 						<button style={{ flex: "1" }} onClick={handleMarkHard}>
 							Hard
+							{intervalPreviews && (
+								<div style={{ fontSize: "0.75em", opacity: 0.7 }}>
+									{intervalPreviews[Rating.Hard]}
+								</div>
+							)}
 						</button>
 						<button
 							className="mod-cta"
@@ -157,9 +219,19 @@ export const SidebarView: React.FC<SidebarViewProps> = ({ app, plugin }) => {
 							onClick={handleMarkGood}
 						>
 							Good
+							{intervalPreviews && (
+								<div style={{ fontSize: "0.75em", opacity: 0.7 }}>
+									{intervalPreviews[Rating.Good]}
+								</div>
+							)}
 						</button>
 						<button style={{ flex: "1" }} onClick={handleMarkEasy}>
 							Easy
+							{intervalPreviews && (
+								<div style={{ fontSize: "0.75em", opacity: 0.7 }}>
+									{intervalPreviews[Rating.Easy]}
+								</div>
+							)}
 						</button>
 					</div>
 				)}

--- a/src/nextNoteSelector.test.ts
+++ b/src/nextNoteSelector.test.ts
@@ -32,13 +32,13 @@ test("returns null when queue is empty", () => {
 	assertEquals(next, null, "Should return null when queue is empty");
 });
 
-// Test: Returns note due today
-test("returns note due today", () => {
+// Test: Returns note due now
+test("returns note due now", () => {
 	const today = new Date();
 	const queue: QueueData = {
 		notes: [
 			{
-				path: "due-today.md",
+				path: "due-now.md",
 				dueDate: today.toISOString(),
 				intervalDays: 1,
 			},
@@ -46,7 +46,7 @@ test("returns note due today", () => {
 	};
 
 	const next = selectNextNote(queue);
-	assertEquals(next, "due-today.md", "Should return note due today");
+	assertEquals(next, "due-now.md", "Should return note due now");
 });
 
 // Test: Returns overdue note
@@ -135,7 +135,7 @@ test("returns null when all notes are in future", () => {
 	assertEquals(
 		next,
 		null,
-		"Should return null when all notes are in future (done for today)",
+		"Should return null when all notes are in future",
 	);
 });
 

--- a/src/nextNoteSelector.ts
+++ b/src/nextNoteSelector.ts
@@ -7,7 +7,7 @@ import { NoteEntry } from "./types";
  */
 export function selectNextNote(dueNotes: NoteEntry[]): string | null {
 	if (dueNotes.length === 0) {
-		return null; // No notes due today
+		return null; // No notes due
 	}
 
 	// Sort by due date (oldest first) and return the most overdue note

--- a/src/nextNoteSelector.ts
+++ b/src/nextNoteSelector.ts
@@ -7,7 +7,7 @@ import { NoteEntry } from "./types";
  */
 export function selectNextNote(dueNotes: NoteEntry[]): string | null {
 	if (dueNotes.length === 0) {
-		return null; // No notes due
+		return null; // No notes due today
 	}
 
 	// Sort by due date (oldest first) and return the most overdue note

--- a/src/queueManager.ts
+++ b/src/queueManager.ts
@@ -120,40 +120,6 @@ export class QueueManager {
 	}
 
 	/**
-	 * Get notes that are due today (anytime today, even if not yet due).
-	 * Used for UI counter display.
-	 */
-	async getNotesScheduledToday(
-		allowCache: boolean = false,
-	): Promise<NoteEntry[]> {
-		const queue = await this.loadQueue(allowCache);
-		const now = new Date();
-		const todayStart = new Date(
-			now.getFullYear(),
-			now.getMonth(),
-			now.getDate(),
-			0,
-			0,
-			0,
-			0,
-		);
-		const todayEnd = new Date(
-			now.getFullYear(),
-			now.getMonth(),
-			now.getDate(),
-			23,
-			59,
-			59,
-			999,
-		);
-
-		return queue.notes.filter((note) => {
-			const dueDate = new Date(note.fsrsCard.due);
-			return dueDate >= todayStart && dueDate <= todayEnd;
-		});
-	}
-
-	/**
 	 * Get queue statistics.
 	 * @param allowCache If true, may return cached data (for UI display).
 	 *                   If false, always loads fresh data (for accuracy).

--- a/src/queueManager.ts
+++ b/src/queueManager.ts
@@ -160,14 +160,12 @@ export class QueueManager {
 	 */
 	async getQueueStats(
 		allowCache: boolean = false,
-	): Promise<{ dueNow: number; dueToday: number; total: number }> {
+	): Promise<{ due: number; total: number }> {
 		const queue = await this.loadQueue(allowCache);
-		const dueNow = await this.getDueNotes(allowCache);
-		const scheduledToday = await this.getNotesScheduledToday(allowCache);
+		const due = await this.getDueNotes(allowCache);
 
 		return {
-			dueNow: dueNow.length,
-			dueToday: scheduledToday.length,
+			due: due.length,
 			total: queue.notes.length,
 		};
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,11 @@
-import { Card } from "ts-fsrs";
+import { Card, ReviewLog, Rating } from "ts-fsrs";
 
 export interface NoteEntry {
 	path: string;
 	// FSRS card data (tracks scheduling, difficulty, stability)
 	fsrsCard: Card;
+	// Review history for analytics and undo functionality
+	reviewLogs?: ReviewLog[];
 }
 
 export interface QueueData {
@@ -15,4 +17,21 @@ export interface LegacyNoteEntry {
 	path: string;
 	dueDate: string;
 	intervalDays: number;
+}
+
+// Card statistics for UI display
+export interface CardStats {
+	stability: number;
+	difficulty: number;
+	reps: number;
+	lapses: number;
+	state: number;
+}
+
+// Interval previews for each rating option
+export interface IntervalPreviews {
+	[Rating.Again]: string;
+	[Rating.Hard]: string;
+	[Rating.Good]: string;
+	[Rating.Easy]: string;
 }


### PR DESCRIPTION
## Summary

This PR simplifies the queue statistics by replacing the separate "due today" and "due now" counters with a single "Due" counter that shows what is currently due.

## Changes

- Removed "Due today" counter from UI
- Changed "Due now" to "Due" in sidebar
- Updated `getQueueStats()` to return only `due` and `total`
- Updated comments and test assertions

Closes #2

Generated with [Claude Code](https://claude.ai/code)