### PR TITLE
Fix: Replace "due today" and "due now" with single "due" counter

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -289,7 +289,7 @@ export default class IncrementalReadingPlugin extends Plugin {
 		}
 
 		await this.queueManager.addToQueue(activeFile.path, 0);
-		new Notice(`Added "${activeFile.basename}" to queue (due today)`);
+		new Notice(`Added "${activeFile.basename}" to queue (due now)`);
 
 		// Update counters
 		if (this.onCountersChanged) {

--- a/src/SidebarView.tsx
+++ b/src/SidebarView.tsx
@@ -15,8 +15,7 @@ interface SidebarViewProps {
  * Renders the pure SidebarViewPure component with data.
  */
 export const SidebarView: React.FC<SidebarViewProps> = ({ app, plugin }) => {
-	const [dueNowCount, setDueNowCount] = useState<number>(0);
-	const [dueTodayCount, setDueTodayCount] = useState<number>(0);
+	const [dueCount, setDueCount] = useState<number>(0);
 	const [totalCount, setTotalCount] = useState<number>(0);
 	const [status, setStatus] = useState<string>("");
 	const [statusHappy, setStatusHappy] = useState<boolean>(false);
@@ -29,8 +28,7 @@ export const SidebarView: React.FC<SidebarViewProps> = ({ app, plugin }) => {
 	const updateCounters = async () => {
 		// Use cache for UI display - it's okay if it's slightly stale
 		const stats = await plugin.queueManager.getQueueStats(true);
-		setDueNowCount(stats.dueNow);
-		setDueTodayCount(stats.dueToday);
+		setDueCount(stats.due);
 		setTotalCount(stats.total);
 	};
 
@@ -112,8 +110,7 @@ export const SidebarView: React.FC<SidebarViewProps> = ({ app, plugin }) => {
 
 	return (
 		<SidebarViewPure
-			dueNowCount={dueNowCount}
-			dueTodayCount={dueTodayCount}
+			dueCount={dueCount}
 			totalCount={totalCount}
 			status={status}
 			statusHappy={statusHappy}

--- a/src/SidebarViewPure.test.tsx
+++ b/src/SidebarViewPure.test.tsx
@@ -18,8 +18,7 @@ describe("SidebarViewPure", () => {
 	describe("Snapshot Tests", () => {
 		test("renders correctly when there are due notes and user is reviewing one", () => {
 			const props: SidebarViewPureProps = {
-				dueNowCount: 5,
-				dueTodayCount: 12,
+				dueCount: 5,
 				totalCount: 25,
 				status: "How was this note? (Use commands or click below)",
 				statusHappy: false,
@@ -46,8 +45,7 @@ describe("SidebarViewPure", () => {
 
 		test("renders correctly when there are no notes to review", () => {
 			const props: SidebarViewPureProps = {
-				dueNowCount: 0,
-				dueTodayCount: 0,
+				dueCount: 0,
 				totalCount: 15,
 				status: "🎉 Done for today! All caught up!",
 				statusHappy: true,
@@ -65,8 +63,7 @@ describe("SidebarViewPure", () => {
 	describe("Additional Scenarios", () => {
 		test("renders correctly when there are notes due later today", () => {
 			const props: SidebarViewPureProps = {
-				dueNowCount: 0,
-				dueTodayCount: 8,
+				dueCount: 0,
 				totalCount: 20,
 				status: "",
 				statusHappy: false,
@@ -82,8 +79,7 @@ describe("SidebarViewPure", () => {
 
 		test("renders correctly with status message after rating", () => {
 			const props: SidebarViewPureProps = {
-				dueNowCount: 3,
-				dueTodayCount: 7,
+				dueCount: 3,
 				totalCount: 18,
 				status: "Scheduled for 2 hours",
 				statusHappy: false,

--- a/src/SidebarViewPure.tsx
+++ b/src/SidebarViewPure.tsx
@@ -3,8 +3,7 @@ import { Rating } from "ts-fsrs";
 import { CardStats, IntervalPreviews } from "./types";
 
 export interface SidebarViewPureProps {
-	dueNowCount: number;
-	dueTodayCount: number;
+	dueCount: number;
 	totalCount: number;
 	status: string;
 	statusHappy: boolean;
@@ -25,8 +24,7 @@ export interface SidebarViewPureProps {
  * All data comes from props, making it easy to test.
  */
 export const SidebarViewPure: React.FC<SidebarViewPureProps> = ({
-	dueNowCount,
-	dueTodayCount,
+	dueCount,
 	totalCount,
 	status,
 	statusHappy,
@@ -54,18 +52,13 @@ export const SidebarViewPure: React.FC<SidebarViewPureProps> = ({
 					borderRadius: "5px",
 				}}
 			>
-				<div style={{ marginBottom: "5px" }}>
-					Due now: {dueNowCount}
-				</div>
-				<div style={{ marginBottom: "5px" }}>
-					Due today: {dueTodayCount}
-				</div>
+				<div style={{ marginBottom: "5px" }}>Due: {dueCount}</div>
 				<div>Total in queue: {totalCount}</div>
 			</div>
 
 			{/* Show Next button - primary only when there are notes to show */}
 			<button
-				className={dueNowCount > 0 ? "mod-cta" : ""}
+				className={dueCount > 0 ? "mod-cta" : ""}
 				style={{ marginBottom: "10px", width: "100%" }}
 				onClick={onShowNext}
 			>
@@ -141,7 +134,9 @@ export const SidebarViewPure: React.FC<SidebarViewPureProps> = ({
 						<button style={{ flex: "1" }} onClick={onMarkAgain}>
 							Again
 							{intervalPreviews && (
-								<div style={{ fontSize: "0.75em", opacity: 0.7 }}>
+								<div
+									style={{ fontSize: "0.75em", opacity: 0.7 }}
+								>
 									{intervalPreviews[Rating.Again]}
 								</div>
 							)}
@@ -149,7 +144,9 @@ export const SidebarViewPure: React.FC<SidebarViewPureProps> = ({
 						<button style={{ flex: "1" }} onClick={onMarkHard}>
 							Hard
 							{intervalPreviews && (
-								<div style={{ fontSize: "0.75em", opacity: 0.7 }}>
+								<div
+									style={{ fontSize: "0.75em", opacity: 0.7 }}
+								>
 									{intervalPreviews[Rating.Hard]}
 								</div>
 							)}
@@ -161,7 +158,9 @@ export const SidebarViewPure: React.FC<SidebarViewPureProps> = ({
 						>
 							Good
 							{intervalPreviews && (
-								<div style={{ fontSize: "0.75em", opacity: 0.7 }}>
+								<div
+									style={{ fontSize: "0.75em", opacity: 0.7 }}
+								>
 									{intervalPreviews[Rating.Good]}
 								</div>
 							)}
@@ -169,7 +168,9 @@ export const SidebarViewPure: React.FC<SidebarViewPureProps> = ({
 						<button style={{ flex: "1" }} onClick={onMarkEasy}>
 							Easy
 							{intervalPreviews && (
-								<div style={{ fontSize: "0.75em", opacity: 0.7 }}>
+								<div
+									style={{ fontSize: "0.75em", opacity: 0.7 }}
+								>
 									{intervalPreviews[Rating.Easy]}
 								</div>
 							)}

--- a/src/__snapshots__/SidebarViewPure.test.tsx.snap
+++ b/src/__snapshots__/SidebarViewPure.test.tsx.snap
@@ -12,14 +12,8 @@ exports[`SidebarViewPure Additional Scenarios renders correctly when there are n
       <div
         style="margin-bottom: 5px;"
       >
-        Due now: 
+        Due: 
         0
-      </div>
-      <div
-        style="margin-bottom: 5px;"
-      >
-        Due today: 
-        8
       </div>
       <div>
         Total in queue: 
@@ -61,14 +55,8 @@ exports[`SidebarViewPure Additional Scenarios renders correctly with status mess
       <div
         style="margin-bottom: 5px;"
       >
-        Due now: 
+        Due: 
         3
-      </div>
-      <div
-        style="margin-bottom: 5px;"
-      >
-        Due today: 
-        7
       </div>
       <div>
         Total in queue: 
@@ -112,14 +100,8 @@ exports[`SidebarViewPure Snapshot Tests renders correctly when there are due not
       <div
         style="margin-bottom: 5px;"
       >
-        Due now: 
+        Due: 
         5
-      </div>
-      <div
-        style="margin-bottom: 5px;"
-      >
-        Due today: 
-        12
       </div>
       <div>
         Total in queue: 
@@ -243,13 +225,7 @@ exports[`SidebarViewPure Snapshot Tests renders correctly when there are no note
       <div
         style="margin-bottom: 5px;"
       >
-        Due now: 
-        0
-      </div>
-      <div
-        style="margin-bottom: 5px;"
-      >
-        Due today: 
+        Due: 
         0
       </div>
       <div>

--- a/src/nextNoteSelector.ts
+++ b/src/nextNoteSelector.ts
@@ -7,7 +7,7 @@ import { NoteEntry } from "./types";
  */
 export function selectNextNote(dueNotes: NoteEntry[]): string | null {
 	if (dueNotes.length === 0) {
-		return null; // No notes due today
+		return null; // No notes due
 	}
 
 	// Sort by due date (oldest first) and return the most overdue note

--- a/src/queueManager.ts
+++ b/src/queueManager.ts
@@ -130,38 +130,6 @@ export class QueueManager {
 	}
 
 	/**
-	 * Get notes that are due today (anytime today, even if not yet due).
-	 * Used for UI counter display.
-	 */
-	async getNotesScheduledToday(allowCache = false): Promise<NoteEntry[]> {
-		const queue = await this.loadQueue(allowCache);
-		const now = new Date();
-		const todayStart = new Date(
-			now.getFullYear(),
-			now.getMonth(),
-			now.getDate(),
-			0,
-			0,
-			0,
-			0,
-		);
-		const todayEnd = new Date(
-			now.getFullYear(),
-			now.getMonth(),
-			now.getDate(),
-			23,
-			59,
-			59,
-			999,
-		);
-
-		return queue.notes.filter((note) => {
-			const dueDate = new Date(note.fsrsCard.due);
-			return dueDate >= todayStart && dueDate <= todayEnd;
-		});
-	}
-
-	/**
 	 * Get queue statistics.
 	 * @param allowCache If true, may return cached data (for UI display).
 	 *                   If false, always loads fresh data (for accuracy).

--- a/src/queueManager.ts
+++ b/src/queueManager.ts
@@ -168,14 +168,12 @@ export class QueueManager {
 	 */
 	async getQueueStats(
 		allowCache = false,
-	): Promise<{ dueNow: number; dueToday: number; total: number }> {
+	): Promise<{ due: number; total: number }> {
 		const queue = await this.loadQueue(allowCache);
 		const dueNow = await this.getDueNotes(allowCache);
-		const scheduledToday = await this.getNotesScheduledToday(allowCache);
 
 		return {
-			dueNow: dueNow.length,
-			dueToday: scheduledToday.length,
+			due: dueNow.length,
 			total: queue.notes.length,
 		};
 	}


### PR DESCRIPTION
## Summary

Simplified the queue statistics by replacing the separate "due today" and "due now" counters with a single "Due" counter that shows what is currently due.

## Changes

- Updated SidebarViewPure component to show only "Due" counter
- Updated props interface to use dueCount instead of dueNowCount/dueTodayCount
- Updated SidebarView container to match new props
- Updated queueManager.getQueueStats() to return only due and total
- Changed notice message from "due today" to "due now"
- Updated comments in nextNoteSelector
- Updated all tests and snapshots

Closes #2

Generated with [Claude Code](https://claude.ai/code)